### PR TITLE
upgrade to org.apache.commons.fileupload2

### DIFF
--- a/apps/examples/pom.xml
+++ b/apps/examples/pom.xml
@@ -44,8 +44,12 @@
          <artifactId>struts-extras</artifactId>
       </dependency>
       <dependency>
-         <groupId>commons-fileupload</groupId>
-         <artifactId>commons-fileupload</artifactId>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-fileupload2-core</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-fileupload2-core</artifactId>
       </dependency>
       <dependency>
          <groupId>commons-io</groupId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -164,8 +164,13 @@
 
     <!-- Include optional dependencies -->
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-core</artifactId>
+      <optional>false</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-jakarta</artifactId>
       <optional>false</optional>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,6 +90,14 @@
             <artifactId>antlr4-runtime</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-fileupload2-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-fileupload2-jakarta</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>
@@ -102,13 +110,13 @@
             <artifactId>commons-digester</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
         </dependency>
+        <dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>

--- a/core/src/main/java/org/apache/struts/upload/CommonsMultipartRequestHandler.java
+++ b/core/src/main/java/org/apache/struts/upload/CommonsMultipartRequestHandler.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -446,7 +447,7 @@ public class CommonsMultipartRequestHandler implements MultipartRequestHandler {
 
         if (!haveValue) {
             try {
-                value = item.getString(Charset.forName("ISO-8859-1"));
+                value = item.getString(StandardCharsets.ISO_8859_1);
             } catch (java.io.UnsupportedEncodingException uee) {
                 value = item.getString();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1167,9 +1167,9 @@
                <version>${tilesRequestVersion}</version>
             </dependency>
             <dependency>
-               <groupId>org.apache.tiles</groupId>
+               <groupId>io.github.weblegacy</groupId>
                <artifactId>tiles-request-servlet</artifactId>
-               <version>${tilesRequestVersion}</version>
+               <version>1.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1004,15 +1004,21 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>1.4</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-fileupload2-core</artifactId>
+                <version>2.0.0-M1</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-fileupload2-jakarta</artifactId>
+                <version>2.0.0-M1</version>
                 <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.13.0</version>
                 <optional>true</optional>
             </dependency>
             <dependency>

--- a/src/site/xdoc/userGuide/release-notes-1_1-b2.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-b2.xml
@@ -280,7 +280,7 @@
                     <strong>FileUpload Package</strong>
                     [
                     <a href="http://cvs.apache.org/viewcvs/jakarta-commons-sandbox/fileupload/">
-                        <code>org.apache.commons.fileupload</code>
+                        <code>org.apache.commons.fileupload2.core</code>
                     </a>
                     ]
                 </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1-b2.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-b2.xml
@@ -279,8 +279,8 @@
                 <li>
                     <strong>FileUpload Package</strong>
                     [
-                    <a href="http://cvs.apache.org/viewcvs/jakarta-commons-sandbox/fileupload/">
-                        <code>org.apache.commons.fileupload2.core</code>
+                    <a href="https://github.com/apache/commons-fileupload/tree/1.x">
+                        <code>org.apache.commons.fileupload</code>
                     </a>
                     ]
                 </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1-b3.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-b3.xml
@@ -322,8 +322,8 @@
                     <li>
                         <strong>FileUpload Package</strong>
                         [
-                        <a href="http://cvs.apache.org/viewcvs/jakarta-commons-sandbox/fileupload/">
-                            <code>org.apache.commons.fileupload2.core</code>
+                        <a href="https://github.com/apache/commons-fileupload/tree/1.x">
+                            <code>org.apache.commons.fileupload</code>
                         </a>
                         ]
                     </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1-b3.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-b3.xml
@@ -323,7 +323,7 @@
                         <strong>FileUpload Package</strong>
                         [
                         <a href="http://cvs.apache.org/viewcvs/jakarta-commons-sandbox/fileupload/">
-                            <code>org.apache.commons.fileupload</code>
+                            <code>org.apache.commons.fileupload2.core</code>
                         </a>
                         ]
                     </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1-rc1.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-rc1.xml
@@ -322,8 +322,8 @@
                     <li>
                         <strong>FileUpload Package</strong>
                         [
-                        <a href="http://cvs.apache.org/viewcvs/jakarta-commons-sandbox/fileupload/">
-                            <code>org.apache.commons.fileupload2.core</code>
+                        <a href="https://github.com/apache/commons-fileupload/tree/1.x">
+                            <code>org.apache.commons.fileupload</code>
                         </a>
                         ]
                     </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1-rc1.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-rc1.xml
@@ -323,7 +323,7 @@
                         <strong>FileUpload Package</strong>
                         [
                         <a href="http://cvs.apache.org/viewcvs/jakarta-commons-sandbox/fileupload/">
-                            <code>org.apache.commons.fileupload</code>
+                            <code>org.apache.commons.fileupload2.core</code>
                         </a>
                         ]
                     </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1-rc2.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-rc2.xml
@@ -695,8 +695,8 @@
                     <li>
                         <strong>FileUpload Package</strong>
                         [
-                        <a href="http://jakarta.apache.org/commons/fileupload/">
-                            <code>org.apache.commons.fileupload2.core</code>
+                        <a href="https://github.com/apache/commons-fileupload/tree/1.x">
+                            <code>org.apache.commons.fileupload</code>
                         </a>
                         ]
                     </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1-rc2.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1-rc2.xml
@@ -696,7 +696,7 @@
                         <strong>FileUpload Package</strong>
                         [
                         <a href="http://jakarta.apache.org/commons/fileupload/">
-                            <code>org.apache.commons.fileupload</code>
+                            <code>org.apache.commons.fileupload2.core</code>
                         </a>
                         ]
                     </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1.xml
@@ -715,7 +715,7 @@
                         <strong>FileUpload Package</strong>
                         [
                         <a href="http://jakarta.apache.org/commons/fileupload/">
-                            <code>org.apache.commons.fileupload</code>
+                            <code>org.apache.commons.fileupload2.core</code>
                         </a>
                         ]
                     </li>

--- a/src/site/xdoc/userGuide/release-notes-1_1.xml
+++ b/src/site/xdoc/userGuide/release-notes-1_1.xml
@@ -714,8 +714,8 @@
                     <li>
                         <strong>FileUpload Package</strong>
                         [
-                        <a href="http://jakarta.apache.org/commons/fileupload/">
-                            <code>org.apache.commons.fileupload2.core</code>
+                        <a href="https://github.com/apache/commons-fileupload/tree/1.x">
+                            <code>org.apache.commons.fileupload</code>
                         </a>
                         ]
                     </li>

--- a/tiles2/pom.xml
+++ b/tiles2/pom.xml
@@ -70,7 +70,7 @@
          <artifactId>tiles-request-api</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.apache.tiles</groupId>
+         <groupId>io.github.weblegacy</groupId>
          <artifactId>tiles-request-servlet</artifactId>
       </dependency>
       <dependency>

--- a/tiles2/src/main/java/org/apache/struts/tiles2/TilesPluginContainer.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/TilesPluginContainer.java
@@ -21,6 +21,8 @@
 
 package org.apache.struts.tiles2;
 
+import io.github.weblegacy.tiles.request.servlet.ServletRequest;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +35,6 @@ import org.apache.tiles.definition.DefinitionsFactory;
 import org.apache.tiles.impl.BasicTilesContainer;
 import org.apache.tiles.locale.LocaleResolver;
 import org.apache.tiles.request.Request;
-import org.apache.tiles.request.servlet.ServletRequest;
 
 public class TilesPluginContainer extends BasicTilesContainer {
 

--- a/tiles2/src/main/java/org/apache/struts/tiles2/TilesRequestProcessor.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/TilesRequestProcessor.java
@@ -21,6 +21,9 @@
 
 package org.apache.struts.tiles2;
 
+import io.github.weblegacy.tiles.request.servlet.ServletRequest;
+import io.github.weblegacy.tiles.request.servlet.ServletUtil;
+
 import java.io.IOException;
 
 import jakarta.servlet.ServletContext;
@@ -37,8 +40,6 @@ import org.apache.tiles.TilesException;
 import org.apache.tiles.access.TilesAccess;
 import org.apache.tiles.request.ApplicationContext;
 import org.apache.tiles.request.Request;
-import org.apache.tiles.request.servlet.ServletRequest;
-import org.apache.tiles.request.servlet.ServletUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tiles2/src/main/java/org/apache/struts/tiles2/actions/DefinitionDispatcherAction.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/actions/DefinitionDispatcherAction.java
@@ -21,6 +21,9 @@
 
 package org.apache.struts.tiles2.actions;
 
+import io.github.weblegacy.tiles.request.servlet.ServletRequest;
+import io.github.weblegacy.tiles.request.servlet.ServletUtil;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -32,8 +35,6 @@ import org.apache.tiles.TilesContainer;
 import org.apache.tiles.access.TilesAccess;
 import org.apache.tiles.request.ApplicationContext;
 import org.apache.tiles.request.Request;
-import org.apache.tiles.request.servlet.ServletRequest;
-import org.apache.tiles.request.servlet.ServletUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tiles2/src/main/java/org/apache/struts/tiles2/actions/TilesAction.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/actions/TilesAction.java
@@ -21,6 +21,9 @@
 
 package org.apache.struts.tiles2.actions;
 
+import io.github.weblegacy.tiles.request.servlet.ServletRequest;
+import io.github.weblegacy.tiles.request.servlet.ServletUtil;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,8 +37,6 @@ import org.apache.tiles.TilesContainer;
 import org.apache.tiles.access.TilesAccess;
 import org.apache.tiles.request.ApplicationContext;
 import org.apache.tiles.request.Request;
-import org.apache.tiles.request.servlet.ServletRequest;
-import org.apache.tiles.request.servlet.ServletUtil;
 
 /**
  * Base class for Tiles Actions.

--- a/tiles2/src/main/java/org/apache/struts/tiles2/commands/TilesPreProcessor.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/commands/TilesPreProcessor.java
@@ -20,6 +20,9 @@
  */
 package org.apache.struts.tiles2.commands;
 
+import io.github.weblegacy.tiles.request.servlet.ServletRequest;
+import io.github.weblegacy.tiles.request.servlet.ServletUtil;
+
 import org.apache.commons.chain.Command;
 import org.apache.commons.chain.Context;
 import org.apache.struts.chain.contexts.ServletActionContext;
@@ -28,8 +31,6 @@ import org.apache.tiles.TilesContainer;
 import org.apache.tiles.access.TilesAccess;
 import org.apache.tiles.request.ApplicationContext;
 import org.apache.tiles.request.Request;
-import org.apache.tiles.request.servlet.ServletRequest;
-import org.apache.tiles.request.servlet.ServletUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tiles2/src/main/java/org/apache/struts/tiles2/preparer/ActionPreparer.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/preparer/ActionPreparer.java
@@ -21,12 +21,14 @@
 
 package org.apache.struts.tiles2.preparer;
 
+import io.github.weblegacy.tiles.request.servlet.ServletRequest;
+
 import org.apache.struts.action.Action;
 import org.apache.tiles.AttributeContext;
 import org.apache.tiles.preparer.PreparerException;
 import org.apache.tiles.preparer.ViewPreparer;
 import org.apache.tiles.request.Request;
-import org.apache.tiles.request.servlet.ServletRequest;
+
 
 /**
  * Struts wrapper implementation of Controller.  This implementation wraps an

--- a/tiles2/src/main/java/org/apache/struts/tiles2/preparer/UrlPreparer.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/preparer/UrlPreparer.java
@@ -23,6 +23,8 @@ package org.apache.struts.tiles2.preparer;
 
 import java.io.IOException;
 
+import io.github.weblegacy.tiles.request.servlet.ServletRequest;
+
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,7 +34,6 @@ import org.apache.tiles.AttributeContext;
 import org.apache.tiles.preparer.PreparerException;
 import org.apache.tiles.preparer.ViewPreparer;
 import org.apache.tiles.request.Request;
-import org.apache.tiles.request.servlet.ServletRequest;
 
 /**
  * @version $Rev$ $Date$

--- a/tiles2/src/main/java/org/apache/struts/tiles2/util/PlugInConfigContextAdapter.java
+++ b/tiles2/src/main/java/org/apache/struts/tiles2/util/PlugInConfigContextAdapter.java
@@ -21,6 +21,8 @@
 
 package org.apache.struts.tiles2.util;
 
+import io.github.weblegacy.tiles.request.servlet.ServletApplicationContext;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +30,6 @@ import java.util.Map;
 import jakarta.servlet.ServletContext;
 
 import org.apache.struts.config.PlugInConfig;
-import org.apache.tiles.request.servlet.ServletApplicationContext;
 
 
 /**

--- a/tiles2/src/test/java/org/apache/struts/tiles2/TestTilesPlugin.java
+++ b/tiles2/src/test/java/org/apache/struts/tiles2/TestTilesPlugin.java
@@ -27,6 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import io.github.weblegacy.tiles.request.servlet.ServletApplicationContext;
+import io.github.weblegacy.tiles.request.servlet.ServletUtil;
+
 import java.lang.reflect.InvocationTargetException;
 
 import jakarta.servlet.ServletException;
@@ -45,8 +48,6 @@ import org.apache.tiles.access.TilesAccess;
 import org.apache.tiles.definition.DefinitionsFactory;
 import org.apache.tiles.request.ApplicationAccess;
 import org.apache.tiles.request.ApplicationContext;
-import org.apache.tiles.request.servlet.ServletApplicationContext;
-import org.apache.tiles.request.servlet.ServletUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This branch contains the necessary changes to namespaces, method calls, maven dependency names and versions, etc. to upgrade from the commons.fileupload API to version 2. My ability to verify these changes was limited by the commons-chain library causing the maven build to fail.